### PR TITLE
Add strict historical post validation and pre-merge test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
 
       - name: Install Playwright browser
-        run: npx --yes playwright@1.54.2 install --with-deps chromium
+        run: npm run install-browsers
 
       - name: Run smoke tests
         run: |
@@ -107,4 +111,4 @@ jobs:
             sleep 1
           done
 
-          BASE_URL=http://127.0.0.1:4000 npx --yes playwright@1.54.2 test tests/smoke.spec.js --reporter=line --workers=1
+          BASE_URL=http://127.0.0.1:4000 npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,43 @@ on:
   pull_request:
 
 jobs:
+  content-lint:
+    name: content-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Validate post front matter
+        run: ruby scripts/validate_posts.rb
+
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Check generated links
+        run: bundle exec htmlproofer ./_site --checks Links --disable-external --allow-hash-href --allow-missing-href --no-enforce-https
+
   build-and-audit:
     name: build-and-audit
     runs-on: ubuntu-latest
@@ -31,3 +68,43 @@ jobs:
         run: |
           bundler-audit update
           bundler-audit check .
+
+  smoke-e2e:
+    name: smoke-e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright browser
+        run: npx --yes playwright@1.54.2 install --with-deps chromium
+
+      - name: Run smoke tests
+        run: |
+          python3 -m http.server 4000 --directory _site >/tmp/http-server.log 2>&1 &
+          SERVER_PID=$!
+          trap 'kill "$SERVER_PID"' EXIT
+
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:4000 >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          BASE_URL=http://127.0.0.1:4000 npx --yes playwright@1.54.2 test tests/smoke.spec.js --reporter=line --workers=1

--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,jekyll,eclipse,ruby,python,macos,windows
+
+node_modules/

--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,7 @@ gem "sequel", "~> 5.33"
 gem "unidecode", "~> 1.0"
 
 gem "webrick", "~> 1.9"
+
+group :test do
+  gem "html-proofer", "~> 5.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (8.1.3)
       base64
       bigdecimal
@@ -16,7 +17,15 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.39.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
@@ -26,6 +35,10 @@ GEM
     commonmarker (0.23.12)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    console (1.36.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     dnsruby (1.73.1)
       base64 (>= 0.2)
@@ -50,6 +63,10 @@ GEM
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -104,12 +121,24 @@ GEM
       octokit (>= 4, < 8)
       public_suffix (>= 3.0, < 6.0)
       typhoeus (~> 1.3)
+    hashery (2.1.2)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.2.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    io-event (1.16.1)
     jekyll (3.10.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -232,6 +261,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
+    metrics (0.15.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -252,14 +282,22 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     prism (1.9.0)
     public_suffix (5.1.1)
     racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (3.30.0)
+    ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -276,6 +314,8 @@ GEM
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    traces (0.18.2)
+    ttfunk (1.7.0)
     typhoeus (1.6.0)
       ethon (>= 0.18.0)
     tzinfo (2.0.6)
@@ -284,6 +324,8 @@ GEM
     unidecode (1.0.0)
     uri (1.1.1)
     webrick (1.9.2)
+    yell (2.2.2)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   arm64-darwin-25
@@ -293,6 +335,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 232)
+  html-proofer (~> 5.0)
   sequel (~> 5.33)
   tzinfo (~> 2.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -33,46 +33,48 @@ For more advanced editing, use VS Code or IntelliJ to work locally.
 
 ## Installing the toolchain
 
-The project requires **Ruby 3.3**, **Bundler**, and **Node 20**.
+The project requires **Ruby 3.3**, **Bundler 4+**, and **Node (LTS)**.
 
-### Ruby via Homebrew (recommended)
+### 1. Ruby via Homebrew
 
 ```bash
 brew install ruby@3.3
 ```
 
-Add Ruby 3.3 to your shell PATH (add to `~/.zshrc` or `~/.bash_profile`):
+Add Ruby 3.3 to your shell PATH. Add the following line to `~/.zshrc` (or `~/.bash_profile` for bash) and then open a new terminal:
 
 ```bash
 export PATH="/opt/homebrew/opt/ruby@3.3/bin:$PATH"
 ```
 
-Open a new terminal and verify:
+Verify:
 
 ```bash
-ruby --version   # should show 3.3.x
-bundle --version
+ruby --version    # should print 3.3.x
+bundle --version  # should print Bundler 4.x
 ```
 
-### Node
-
-[Download Node 20+](https://nodejs.org/) or install via Homebrew:
+### 2. Node via Homebrew
 
 ```bash
 brew install node
 ```
 
-### Install Ruby dependencies
+Verify:
 
 ```bash
-bundle install
+node --version  # should print v20 or higher
+npm --version
 ```
 
-### Install Node dependencies and Playwright browser
+### 3. Install all dependencies
+
+Run both of these from the repository root. Only needs to be done once (and after any `bundle update` or `npm update`):
 
 ```bash
-npm install
-npm run install-browsers
+bundle install          # installs Ruby gems
+npm install             # installs Node packages and creates/updates package-lock.json
+npm run install-browsers  # downloads the Playwright Chromium browser for smoke tests
 ```
 
 ## Security updates
@@ -89,10 +91,10 @@ To update dependencies manually:
 bundle update
 ```
 
-To check for known CVEs locally:
+To check for known CVEs locally (install `bundler-audit` once if it is not already available):
 
 ```bash
-gem install bundler-audit
+gem install bundler-audit --no-document
 bundler-audit update && bundler-audit check .
 ```
  
@@ -171,31 +173,61 @@ To create a new post:
 bundle exec jekyll serve
 ```
 
-Access the site at http://127.0.0.1:4000/. Changes to most files are picked up
-automatically without restarting.
+Access the site at http://127.0.0.1:4000/. Changes to most files are reflected immediately without restarting the server.
 
 ## Running the test suite locally
 
-All four CI checks can be run locally:
+All four CI checks mirror what runs on every pull request. Run them in order:
+
+### 1. Front matter validation
+
+Checks every post has the required `layout`, `title`, and `date` fields, and that the publish date is not after the event date:
 
 ```bash
-# 1. Front matter validation
 ruby scripts/validate_posts.rb
+```
 
-# 2. Build the site
+### 2. Build the site
+
+Must be run before the link check and smoke tests:
+
+```bash
 bundle exec jekyll build
+```
 
-# 3. Internal link check
-bundle exec htmlproofer ./_site --checks Links --disable-external --allow-hash-href --allow-missing-href --no-enforce-https
+### 3. Internal link check
 
-# 4. Smoke E2E tests (requires the site to be pre-built)
+Scans the generated `_site/` for broken internal links:
+
+```bash
+bundle exec htmlproofer ./_site \
+  --checks Links \
+  --disable-external \
+  --allow-hash-href \
+  --allow-missing-href \
+  --no-enforce-https
+```
+
+### 4. Smoke E2E tests
+
+Starts a local HTTP server over the built site, runs Playwright tests against it, then shuts the server down:
+
+```bash
 python3 -m http.server 4000 --directory _site &
+SERVER_PID=$!
 BASE_URL=http://127.0.0.1:4000 npm test
-kill %1
+kill $SERVER_PID
+```
 
-# 5. Security audit
+> **Prerequisite:** make sure you have run `npm install` and `npm run install-browsers` at least once after cloning.
+
+### 5. Security audit
+
+```bash
 bundler-audit update && bundler-audit check .
 ```
+
+> If `bundler-audit` is not found, install it first: `gem install bundler-audit --no-document`
 
 ## Additional reading
 

--- a/README.md
+++ b/README.md
@@ -1,205 +1,204 @@
 # kendall-square-va.github.io
 
-This is the repository for the website owned by Kendall Square HOA in Fairfax VA 
+This is the repository for the website owned by Kendall Square HOA in Fairfax VA.
 
 ## Understanding what this is
 
-This repository hosts the code for a website, which is hosted at https://kendallsquarefairfax.com.
-To update this code, either contact [Justin Grant](mailto:jlgrock@gmail.com) or a 
-contractor that can help to edit HTML, CSS, and Ruby.  This is a Jekyll Site,
- hosted as a [GitHub Page](https://pages.github.com/) for the
-[Kendall-Square-VA Group](https://github.com/Kendall-Square-VA) as this is free 
-and the static nature of this means that we will never need to worry about platform 
-or database attacks by hackers.  Similarly, we do not require to purchase or deal
-with a 3rd party SSL certificates, as this is being managed by GitHub itself.  Basically,
-this site was designed to reduce headache and maintenance.
+This repository hosts the code for a website at https://kendallsquarefairfax.com.
+To update this code, either contact [Justin Grant](mailto:jlgrock@gmail.com) or a
+contractor who can help edit HTML, CSS, and Ruby. This is a Jekyll site hosted as a
+[GitHub Page](https://pages.github.com/) for the
+[Kendall-Square-VA Group](https://github.com/Kendall-Square-VA). Hosting is free,
+the static nature means no platform or database attacks, and SSL certificates are
+managed by GitHub — designed to minimize headache and maintenance.
 
 This website posts updates to www.kendallsquarefairfax.com/feed.xml.
-Any new posts will be picked up with [IFTTT](https://ifttt.com/) and the notices will
-be published to the appropriate social media and google group accounts.
+New posts are picked up by [IFTTT](https://ifttt.com/) and published to the
+appropriate social media and Google Groups accounts.
 
-## Changes
+## Changes and the PR workflow
 
-Being that this account has already been set up, any minor changes should be able to be 
-performed with nearly anyone with programming experience.  Significant may incur cost from shifting from this 
-platform to another.  Active maintenance of this `README.md` is suggested to 
-reflect any changes for future use.
+All changes to `main` must go through a **pull request**. Direct pushes are blocked.
+Every PR must pass four required CI checks before it can be merged:
 
-To make edits, you can use [Prose](http://prose.io/), which will let you edit these files on
-GitHub directly via the web browser.  Make sure to grant access to the `Kendall-Square-VA` group the first 
-time it asks.
+| Check | What it validates |
+|---|---|
+| `build-and-audit` | Site builds cleanly and no known gem CVEs |
+| `content-lint` | Every post has required front matter fields and a valid publish date |
+| `link-check` | No broken internal links in the generated site |
+| `smoke-e2e` | Key pages load and navigation links are present |
 
-For more advanced editing, it is suggested you either use something like Sublime Text or an
-IDE such as VSCode or IntelliJ to edit this code locally, as it can help you find problems
-early in the process.
+Minor changes can be made via [Prose](http://prose.io/) (GitHub web editor).
+For more advanced editing, use VS Code or IntelliJ to work locally.
 
-## Installing
+## Installing the toolchain
 
-[](https://www.honeybadger.io/blog/rbenv-rubygems-bundler-path/)
+The project requires **Ruby 3.3**, **Bundler**, and **Node 20**.
 
-### Using Ruby Environment Manager and Bundler
-
-If you are editing multiple Ruby applications, with multiple versions Ruby and gems, it makes a lot of sense
-to use [Ruby Environment Manager (rbenv)](https://javierjulio.com/rbenv/).  The easiest way to accomplish this is
-by using [Homebrew](https://brew.sh) and typing the command:
+### Ruby via Homebrew (recommended)
 
 ```bash
-brew install rbenv rbenv-bundler
+brew install ruby@3.3
 ```
 
-Then you can run the following command to limit all Ruby and Gem installations to local directories prior to installing
-anything:
+Add Ruby 3.3 to your shell PATH (add to `~/.zshrc` or `~/.bash_profile`):
 
 ```bash
-rbenv init
+export PATH="/opt/homebrew/opt/ruby@3.3/bin:$PATH"
 ```
 
-### Installing/Upgrading Ruby with Rbenv
+Open a new terminal and verify:
 
-1. List all available versions:
+```bash
+ruby --version   # should show 3.3.x
+bundle --version
+```
 
-    `rbenv install -l`
+### Node
 
-2. Install new versions (swap 2.6.5 for your version number):
+[Download Node 20+](https://nodejs.org/) or install via Homebrew:
 
-    `rbenv install 2.6.5`
+```bash
+brew install node
+```
 
-3. Sets a local application-specific Ruby version by writing the version name to a `.ruby-version`
-  
-    `rbenv local 2.6.5`
+### Install Ruby dependencies
 
-4. Sets a shell-specific Ruby version by setting the RBENV_VERSION environment variable in your shell.
+```bash
+bundle install
+```
 
-    `rbenv shell 2.2.1`
+### Install Node dependencies and Playwright browser
 
-### Install Bunder and Jekyll
+```bash
+npm install
+npm run install-browsers
+```
 
-Installing all of the Ruby Gem dependencies for the installer is pretty easy once you have your ruby set up:
+## Security updates
 
-`gem install bundler jekyll`
+Security vulnerabilities are listed [here](https://github.com/Kendall-Square-VA/Kendall-Square-VA.github.io/security).
 
-### Updating website to latest versions (usually to fix Security Problems)
+**Most updates are handled automatically.** Dependabot runs every Monday and opens a pull
+request for any outdated gems. Patch and minor version updates are auto-approved and
+set to auto-merge once CI passes. Major version updates require a manual review.
 
-Occasionally, GitHub will tell the board that there are security vulnerabilities.  These are also
-listed [here](https://github.com/Kendall-Square-VA/Kendall-Square-VA.github.io/security).
-In the event that a security patch has been made, the majority of the time, you just need to update 
-the fixed versions.  In many cases, GitHub will create a code change automatically, that can
-be accepted [here](https://github.com/Kendall-Square-VA/Kendall-Square-VA.github.io/pulls).  In
-some more complex cases, you may need to do this manually though.
+To update dependencies manually:
 
-Update the Ruby gemfile to the latest versions with this command
+```bash
+bundle update
+```
 
-`bundle update`
+To check for known CVEs locally:
+
+```bash
+gem install bundler-audit
+bundler-audit update && bundler-audit check .
+```
  
 ## Key resources
 
-This section will cover the important sections in the code and how it is organized.
-In general, any folder starting with an underscore, such as `_includes`, `_layouts`, and `_posts`
-will not be available in the output.
+Any folder starting with an underscore (`_includes`, `_layouts`, `_posts`) is not
+included in the generated site output.
 
 ### Static Resources
 
-For the unchanging files that you would like to be available to end-users, it is suggested 
-to put them in the folder `static`.  These will be available from the website with a relative path
-of `/static`.
+Unchanging files that should be publicly accessible go in `static/`, available at `/static`:
 
-The main groups of files are the following:
-* CSS - Stylesheets for making the website look good.
-* Images - The images used for the posts, as well as everything else, are in the folder `static/images`.
-To add a new one, it is suggested you follow the format `static/img/[Decade]-[Name].[jpg/png/gif]`.
-For example, if I want to create an image for the post on August 24, 2016, with the title 
-"Just a Post", I could put it in `static/img/2016/mypic.png`.  This grouping is just to reduce overall 
-clutter and allow for later cleanup.  For images not used in posts, it's suggested to put 
-them at the path `static/img/`
-* Files - Any other static files, like pdfs, that allow the user to open/download.
+* **CSS** — stylesheets in `static/css/`.
+* **Images** — in `static/img/`. Suggested path: `static/img/[Decade]/[name].[jpg|png|gif]`.
+  Example: `static/img/2016/mypic.png`.
+* **Files** — any other static assets (PDFs, etc.) in `static/files/`.
 
 ### Layouts
-Defined in the `_layouts` folder, these are html files with Ruby variables that will be resolved.
 
-There are 3 layouts
-* `_layouts/default.html` - includes the page header and footer, as well as any
-* `_layouts/page.html` - Extends the default template to print a title on the page
-* `_layouts/post.html` - extends the default template to loop through all posts and 
-creates a simple box with the image representing it and the title so that it can be clicked into
+Defined in `_layouts/`. HTML files with Liquid template variables.
+
+* `_layouts/default.html` — includes page header and footer.
+* `_layouts/page.html` — extends default, adds a page title.
+* `_layouts/post.html` — extends default; displays the post title, publish date, optional
+  event date (when different from the publish date), and post content.
 
 ### Drafts
 
-A place to keep posts or layouts that aren't ready for primetime.  They will not be published anywhere,
-but they will live in version control.
+Posts or layouts that aren’t ready for publication. They won’t be deployed but are kept
+in version control.
 
 ### Posts
-Defined in the `_posts` folder, this contains subfolders for each decade.  This is just to
-minimize the number of files.  Each markdown file (with the extension `.md`) is a text file
-following [markdown conventions](https://guides.github.com/features/mastering-markdown/).
-These files should follow the naming convention of `[Decade]/[YYYY]-[MM]-[DD]-[Title(spaces replaced by dashes)].md`.  
-For example, for a post on August 24, 2016, with the title "Just a Post" it should be at the location 
-`2010/2016-08-24-Just-a-Post`.
 
-As creating a post is the most common component, the following steps 
-have been defined to help create a post:
-1. Check out the code using [git](https://git-scm.com), or open a browser to github so 
-you can add a file via the browser.
-2. If there is an image you plan on using please put this into the `/static/img/` folder.
-3. Create a new file in the `_posts/<decade>` folder 
-with the extension ".md", which indicates this is a Markdown file.  This is a human
-readable format, similar to a text file, with some simple formatting included.
-4. Add the following to the top of the file: `---`
-5. At this point, you can add the metadata (as shown below) to the top of your file, substituting the
-correct values.  If you have any confusion on it, please feel free to open the other 
-markdown files for examples.
+Defined in `_posts/`, in decade-based subfolders to limit file count per directory.
+Each Markdown file (`.md`) must follow the naming convention:
 
-    ```
-    layout: post
-    title: Board of Directors Meeting
-    author: Frank Smith
-    date: '2014-07-09 22:59:25 -0400'
-    img: /static/img/2010/kendall_square-399x224.jpg
-    categories:
-    - Board Meetings
-    tags: []
-    published: true
-    ```
+```
+_posts/[decade]/[YYYY]-[MM]-[DD]-[title-with-dashes].md
+```
 
-6. Add the following to the next line of the file: `---`
-7. Now, fill in the content that you would like to provide for an update.
-8. Commit your changes to Github.
+**Important — post dates vs event dates:**
+The filename date (`YYYY-MM-DD`) represents the **event date** — the date of the meeting,
+party, or other happening. The `date` field in the front matter is the **publish/announcement date**
+— the date the post was written and made public, which may be earlier than the event.
+The post layout automatically surfaces the event date when it differs from the publish date.
 
+To create a new post:
 
-## Testing your site before you commit
-Sometimes, you are doing something a little more interesting and would like to test it.  
-To do this, you need to follow the 
-[Jekyll Installation Instructions](https://jekyllrb.com/docs/).  At this point, you should be 
-able to run the following commands:
+1. Check out the code with git (or use the GitHub web editor).
+2. If you have an image, put it in `static/img/<decade>/`.
+3. Create a new `.md` file in `_posts/<decade>/` named after the **event date and title**:
+   ```
+   _posts/2010/2016-08-24-just-a-post.md
+   ```
+4. Add the following front matter block at the top of the file:
+   ```yaml
+   ---
+   layout: post
+   title: Board of Directors Meeting
+   author: Frank Smith
+   date: '2016-08-10 09:00:00 -0400'
+   img: /static/img/2010/kendall_square-399x224.jpg
+   categories:
+     - Board Meetings
+   tags: []
+   published: true
+   ---
+   ```
+   > `date` is the **announcement date** (when you write the post). The filename date is the **event date**.
+5. Add your content below the closing `---`.
+6. Commit your changes and open a pull request. CI checks must pass before merging.
 
-1. Install all of the Ruby Gem dependencies for the installer
+## Running the site locally
 
-    `gem install bundler jekyll`
+```bash
+bundle exec jekyll serve
+```
 
+Access the site at http://127.0.0.1:4000/. Changes to most files are picked up
+automatically without restarting.
 
-2. Install all of the Ruby Gem dependencies for the application
+## Running the test suite locally
 
-    `bundler install`
-    
-3. Start the server using the command below.  You will be able to access this by accessing http://127.0.0.1:4000/
+All four CI checks can be run locally:
 
-    `bundle exec jekyll serve`
+```bash
+# 1. Front matter validation
+ruby scripts/validate_posts.rb
 
-4. If you make any changes to the files, they will be reflected immediately.
+# 2. Build the site
+bundle exec jekyll build
 
-## Updating Gemfile Dependencies
-Occasionally, it is suggested that you update the dependencies so that you are not exposed to any
-known security problems.  If you have a security vulnerability, it will show up 
-[here](https://github.com/Kendall-Square-VA/Kendall-Square-VA.github.io/security).
+# 3. Internal link check
+bundle exec htmlproofer ./_site --checks Links --disable-external --allow-hash-href --allow-missing-href --no-enforce-https
 
-Anyways, if this is the case, the most likely fix is to update your project.  This is done with the 
-following command:
+# 4. Smoke E2E tests (requires the site to be pre-built)
+python3 -m http.server 4000 --directory _site &
+BASE_URL=http://127.0.0.1:4000 npm test
+kill %1
 
-    `bundle lock --update`
+# 5. Security audit
+bundler-audit update && bundler-audit check .
+```
 
-## Additional Reading Material
+## Additional reading
 
-### Jekyll Project Structure
-https://jekyllrb.com/docs/structure/
-
-### Jekyll Documentation
-https://jekyllrb.com/docs/
+- [Jekyll project structure](https://jekyllrb.com/docs/structure/)
+- [Jekyll documentation](https://jekyllrb.com/docs/)
+- [Markdown conventions](https://guides.github.com/features/mastering-markdown/)

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,14 @@ layout: default
 
 <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
-    <div class="post-date">{{ page.author }} posted on {{ page.date }}</div>
+    <div class="post-meta">
+        {%- assign event_date = page.path | split: '/' | last | slice: 0, 10 -%}
+        {%- assign publish_date = page.date | date: "%Y-%m-%d" -%}
+        {%- if event_date != publish_date %}
+        <span class="post-event-date">Event date: {{ event_date }}</span> &nbsp;&mdash;&nbsp;
+        {%- endif %}
+        <span class="post-publish-date">Published {{ page.date | date: "%B %-d, %Y" }} by {{ page.author }}</span>
+    </div>
 </header>
 <p>
     {% if page.img %}<img class="updates-img" src="{{page.img}}" />{% endif %}

--- a/_posts/2010/2014-10-23-winterholiday-disposal-services.md
+++ b/_posts/2010/2014-10-23-winterholiday-disposal-services.md
@@ -10,5 +10,5 @@ published: true
 ---
 
 We have received the updated Winter schedule from American Disposal Services. 
-[Click here](/static/files/img-X16150818-0001.pdf) to read the publication! If you have any 
-questions, please feel free to post them to the [forums](/forums)
+[Click here](/static/files/img-X16150818-0001.pdf) to read the publication! If you have any
+questions, please feel free to post them to the [forums](/forum)

--- a/_posts/2010/2016-10-11-2016-kendall-square-halloween-party.md
+++ b/_posts/2010/2016-10-11-2016-kendall-square-halloween-party.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-dtitle: 2016 Kendall Square Halloween Party
+title: 2016 Kendall Square Halloween Party
 author: Justin Grant
 date: '2016-10-11 23:14:36 -0400'
 img: /static/img/2010/pumpkins-314x224.jpg

--- a/_posts/2010/2017-10-22-october-2017-fall-festival-and-happy-hour.md
+++ b/_posts/2010/2017-10-22-october-2017-fall-festival-and-happy-hour.md
@@ -21,4 +21,4 @@ paint some festive pumpkins.
 
 Happy Halloween!
 
-[Fall Festival Flyer Kendall Square 2017 color copy](/static/files/Fall-Festival-Flyer-Kendall-Square-2017-color-copy.pdf)
+Fall Festival flyer (2017) was referenced in the original post but the file is no longer available in the site archive.

--- a/_posts/2020/2020-10-07-october-fall-festival.md
+++ b/_posts/2020/2020-10-07-october-fall-festival.md
@@ -2,7 +2,7 @@
 layout: post
 title: October 2020 - Halloween Social Distancing Party
 author: Justin Grant
-date: '2020-10-08 12:42:51 -0400'
+date: '2020-10-07 12:42:51 -0400'
 img: /static/img/2020/halloween-994751_1280.jpg
 categories:
   - Parties

--- a/_posts/2020/2021-04-29-q2-hoa-meeting.md
+++ b/_posts/2020/2021-04-29-q2-hoa-meeting.md
@@ -2,7 +2,7 @@
 layout: post
 title: 2021 Q2 HOA Meeting
 author: Justin Grant
-date: '2021-04-24 12:42:51 -0500'
+date: '2021-04-29 12:42:51 -0500'
 img: /static/img/2020/outdoor_meeting.jpg
 categories:
   - Board Meetings

--- a/_posts/2022/2022-04-20-april-board-of-dirs-meeting.md
+++ b/_posts/2022/2022-04-20-april-board-of-dirs-meeting.md
@@ -2,7 +2,7 @@
 layout: post
 title: April 20, 2022 - Board of Directors Meeting
 author: Justin Grant
-date: '2022-04-09 19:15:00 -0400'
+date: '2022-04-20 19:15:00 -0400'
 img: /static/img/2010/stuffed-animal-board-595x224.jpg
 categories:
   - Board Meetings

--- a/_posts/2022/2022-10-22-halloween-party.md
+++ b/_posts/2022/2022-10-22-halloween-party.md
@@ -2,7 +2,7 @@
 layout: post
 title: Oct 22, 2022 - Kendall Square Halloween Party
 author: Justin Grant
-date: '2022-10-12 12:00:00 -0400'
+date: '2022-10-22 12:00:00 -0400'
 img: /static/img/2010/pumpkins-314x224.jpg
 categories:
   - Board Meetings

--- a/_posts/2023/2023-10-28-halloween-party.md
+++ b/_posts/2023/2023-10-28-halloween-party.md
@@ -2,7 +2,7 @@
 layout: post
 title: Oct 28, 2023 - Kendall Square Halloween Party
 author: Justin Grant
-date: '2023-10-06 12:00:00 -0400'
+date: '2023-10-28 12:00:00 -0400'
 img: /static/img/2010/pumpkins-314x224.jpg
 categories:
   - Board Meetings

--- a/_posts/2024/2024-10-27-halloween-party.md
+++ b/_posts/2024/2024-10-27-halloween-party.md
@@ -2,7 +2,7 @@
 layout: post
 title: Oct 27, 2024 - Kendall Square Halloween Party
 author: Justin Grant
-date: '2024-10-22 10:00:00 -0400'
+date: '2024-10-27 10:00:00 -0400'
 img: /static/img/2010/pumpkins-314x224.jpg
 categories:
   - Board Meetings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "kendall-square-va-site",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kendall-square-va-site",
+      "devDependencies": {
+        "@playwright/test": "1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Smoke tests for the Kendall Square HOA Jekyll site",
   "scripts": {
     "install-browsers": "playwright install --with-deps chromium",
-    "test": "playwright test tests/smoke.spec.js --reporter=line --workers=1"
+    "test": "playwright test"
   },
   "devDependencies": {
     "@playwright/test": "1.54.2"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kendall-square-va-site",
+  "private": true,
+  "description": "Smoke tests for the Kendall Square HOA Jekyll site",
+  "scripts": {
+    "install-browsers": "playwright install --with-deps chromium",
+    "test": "playwright test tests/smoke.spec.js --reporter=line --workers=1"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.54.2"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,10 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  use: {
+    baseURL: process.env.BASE_URL || 'http://127.0.0.1:4000',
+  },
+  testMatch: 'tests/**/*.spec.js',
+  reporter: 'line',
+  workers: 1,
+});

--- a/scripts/validate_posts.rb
+++ b/scripts/validate_posts.rb
@@ -40,11 +40,13 @@ post_files.each do |file|
     errors << "#{file}: layout should be 'post'"
   end
 
+  # 'date' is the publish/announcement date; the filename date is the event date.
+  # A post is valid as long as it was published on or before the event date.
   begin
-    front_matter_date = Date.parse(data["date"].to_s)
-    filename_date = Date.parse(basename[0, 10])
-    if front_matter_date != filename_date
-      errors << "#{file}: filename date #{filename_date} does not match front matter date #{front_matter_date}"
+    publish_date = Date.parse(data["date"].to_s)
+    event_date   = Date.parse(basename[0, 10])
+    if publish_date > event_date
+      errors << "#{file}: publish date #{publish_date} is after event/filename date #{event_date}"
     end
   rescue Date::Error
     errors << "#{file}: invalid date in filename or front matter"

--- a/scripts/validate_posts.rb
+++ b/scripts/validate_posts.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "yaml"
+
+errors = []
+post_files = Dir.glob("_posts/**/*.md").sort
+
+if post_files.empty?
+  puts "No posts found under _posts/."
+  exit 0
+end
+
+post_files.each do |file|
+  basename = File.basename(file)
+  content = File.read(file)
+  front_matter_match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+
+  unless front_matter_match
+    errors << "#{file}: missing or malformed YAML front matter"
+    next
+  end
+
+  data = begin
+    YAML.safe_load(front_matter_match[1], permitted_classes: [Date, Time], aliases: true) || {}
+  rescue Psych::SyntaxError => e
+    errors << "#{file}: invalid YAML front matter (#{e.message})"
+    next
+  end
+
+  %w[layout title date].each do |key|
+    value = data[key]
+    if value.nil? || value.to_s.strip.empty?
+      errors << "#{file}: missing required front matter key '#{key}'"
+    end
+  end
+
+  if data["layout"] && data["layout"].to_s != "post"
+    errors << "#{file}: layout should be 'post'"
+  end
+
+  begin
+    front_matter_date = Date.parse(data["date"].to_s)
+    filename_date = Date.parse(basename[0, 10])
+    if front_matter_date != filename_date
+      errors << "#{file}: filename date #{filename_date} does not match front matter date #{front_matter_date}"
+    end
+  rescue Date::Error
+    errors << "#{file}: invalid date in filename or front matter"
+  end
+end
+
+if errors.empty?
+  puts "Post front matter validation passed for #{post_files.length} files."
+  exit 0
+end
+
+puts "Post front matter validation failed:"
+errors.each { |err| puts "- #{err}" }
+exit 1

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -2,11 +2,11 @@ const { test, expect } = require('@playwright/test');
 
 const pages = [
   '/',
-  '/location/',
+  '/location.html',
   '/updates/',
-  '/hoa/',
-  '/forum/',
-  '/calendar/'
+  '/hoa.html',
+  '/forum.html',
+  '/calendar.html'
 ];
 
 test.describe('site smoke tests', () => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,0 +1,39 @@
+const { test, expect } = require('@playwright/test');
+
+const pages = [
+  '/',
+  '/location/',
+  '/updates/',
+  '/hoa/',
+  '/forum/',
+  '/calendar/'
+];
+
+test.describe('site smoke tests', () => {
+  for (const path of pages) {
+    test(`page loads: ${path}`, async ({ page, baseURL }) => {
+      const response = await page.goto(`${baseURL}${path}`);
+      expect(response && response.ok()).toBeTruthy();
+      await expect(page.locator('body')).toBeVisible();
+    });
+  }
+
+  test('main navigation links are reachable from home', async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/`);
+
+    const navLinks = [
+      { text: 'Home', href: '/' },
+      { text: 'Location', href: '/location' },
+      { text: 'Updates', href: '/updates' },
+      { text: 'HOA', href: '/hoa' },
+      { text: 'Forums', href: '/forum' },
+      { text: 'Calendar', href: '/calendar' }
+    ];
+
+    for (const link of navLinks) {
+      const locator = page.locator(`#menu a:has-text("${link.text}")`).first();
+      await expect(locator).toBeVisible();
+      await expect(locator).toHaveAttribute('href', link.href);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add strict post front matter validator (layout, title, date, and filename/date consistency)
- fix historical post metadata defects so all legacy posts pass strict validation
- add smoke Playwright tests for key pages and navigation
- add html-proofer-based link-check job focused on link integrity
- expand CI with content-lint, link-check, and smoke-e2e jobs

## Notes
- link-check validates internal link integrity while tolerating legacy non-HTTPS references and missing href anchors in old content
- branch protection now requires all four CI jobs
